### PR TITLE
[TASK] add configuration to hide apple buy button on non-checkout pages

### DIFF
--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -405,6 +405,7 @@
                 <allow_quest_checkout>1</allow_quest_checkout>
                 <change_address>1</change_address>
                 <show_in_payment_step_checkout>1</show_in_payment_step_checkout>
+                <show_outside_of_checkout>1</show_outside_of_checkout>
                 <allow_billing_agreement_wizard>0</allow_billing_agreement_wizard>
             </adyen_apple_pay>
         </payment>

--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -1955,6 +1955,19 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </show_in_payment_step_checkout>
+                        <show_outside_of_checkout>
+                            <label>Show Apple buy button on product and cart page</label>
+                            <tooltip>Set this to 'no' if you have advanced options for, for example, shipping that are not supported by the Apple Pay checkout forcing the user to first go through the Magento Checkout</tooltip>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>90</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends>
+                                <show_in_payment_step_checkout>1</show_in_payment_step_checkout>
+                            </depends>
+                        </show_outside_of_checkout>
                     </fields>
                 </adyen_apple_pay>
                 <!-- @Elv only -->

--- a/app/design/frontend/base/default/layout/adyen.xml
+++ b/app/design/frontend/base/default/layout/adyen.xml
@@ -54,7 +54,7 @@
         </reference>
         <reference name="checkout.cart.methods">
             <block type="adyen/posExpressCheckout" before="-" name="adyen.pos.express.checkout" template="adyen/pos_express_checkout.phtml"/>
-            <block type="adyen/ApplePay" after="adyen.pos.express.checkout" name="adyen.applepay.express.checkout" template="adyen/apple_pay.phtml" />
+            <block type="adyen/ApplePay" after="adyen.pos.express.checkout" ifconfig="payment/adyen_apple_pay/show_outside_of_checkout" name="adyen.applepay.express.checkout" template="adyen/apple_pay.phtml" />
         </reference>
     </checkout_cart_index>
 
@@ -156,7 +156,7 @@
             <action method="addCss"><stylesheet>css/adyen.css</stylesheet></action>
         </reference>
         <reference name="product.info.addtocart">
-            <block type="adyen/ApplePay" name="adyen.applepay.express.checkout" template="adyen/apple_pay.phtml" />
+            <block type="adyen/ApplePay" ifconfig="payment/adyen_apple_pay/show_outside_of_checkout" name="adyen.applepay.express.checkout" template="adyen/apple_pay.phtml" />
         </reference>
 
     </catalog_product_view>


### PR DESCRIPTION
when shop has advanced shipping options in checkout it might be wise to force user
through checkout instead of direct payment