### PR TITLE
Added the possibility to hook into the refused authorization response…

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -529,6 +529,10 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
                     $errorMsg = Mage::helper('adyen')->__('The payment is REFUSED.');
                 }
 
+                $errorMsg = new Varien_Object(array('error_message' => $errorMsg));
+                Mage::dispatchEvent('adyen_payment_authorize_refused_error', array('responseResult' => $response->paymentResult, 'error' => $errorMsg));
+                $errorMsg = $errorMsg->getErrorMessage();
+
                 $this->resetReservedOrderId();
                 Adyen_Payment_Exception::throwException($errorMsg);
                 break;


### PR DESCRIPTION
This allows customers to add custom error message. Either general or like for us we have enabled the advanced error messages from Adyen and we can look into the real reason and add a customer error message.

Example of use:

`$data = $observer->getData('responseResult');

        $error = $observer->getData('error');

        foreach($data->additionalData->entry as $part) {
            if($part->key == "refusalReasonRaw") {
                if (strpos($part->value, 'DO NOT HONOR') !== false) {
                    $error->errorMessage = 'Payment was refused by your bank. Please contant your bank to make sure that your card is enabled for internet and international payments';
                }
            }
        }`