### PR TITLE
[add] specify multiple IPs for POS IP filter

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Pos.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Pos.php
@@ -54,12 +54,24 @@ class Adyen_Payment_Model_Adyen_Pos extends Adyen_Payment_Model_Adyen_Abstract {
         // check if ip range is enabled
         $ipFilter = $this->_getConfigData('ip_filter', 'adyen_pos');
 
-        if($isAvailable && $ipFilter) {
-            // check if ip is in range
+        if($isAvailable && $ipFilter != 0) {
             $ip =  Mage::helper('adyen')->getClientIp();
-            $from =  $this->_getConfigData('ip_filter_from', 'adyen_pos');
-            $to =  $this->_getConfigData('ip_filter_to', 'adyen_pos');
-            $isAvailable = Mage::helper('adyen')->ipInRange($ip, $from, $to);
+            switch ($ipFilter) {
+                case '1':
+                    // check if ip in in list
+                    $_list = $this->_getConfigData('ip_filter_ips', 'adyen_pos');
+                    $_list = str_replace(' ', '', $_list);
+                    $_list = explode(',', $_list);
+                    $isAvailable = in_array($ip, $_list);
+                    break;
+                case '2':
+                default:
+                    // check if ip is in range
+                    $from =  $this->_getConfigData('ip_filter_from', 'adyen_pos');
+                    $to =  $this->_getConfigData('ip_filter_to', 'adyen_pos');
+                    $isAvailable = Mage::helper('adyen')->ipInRange($ip, $from, $to);
+                    break;
+            }
         }
         return $isAvailable;
     }

--- a/app/code/community/Adyen/Payment/Model/Source/POS/IpFilter.php
+++ b/app/code/community/Adyen/Payment/Model/Source/POS/IpFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Adyen Payment Module
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * @category  Adyen
+ * @package Adyen_Payment
+ * @copyright Copyright (c) 2016 AAOO Tech Ltd. (http://www.aaoo-tech.com)
+ * @license http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+/**
+ * @category   Payment Gateway
+ * @package    Adyen_Payment
+ * @author     AAOO
+ * @property   AAOO Tech Ltd.
+ * @copyright  Copyright (c) 2016 AAOO Tech Ltd. (http://www.aaoo-tech.com)
+ */
+
+class Adyen_Payment_Model_Source_POS_IpFilter {
+    public function toOptionArray() {
+        $_options = [
+            [ 'value' => '0', 'label' => 'Disabled' ],
+            [ 'value' => '1', 'label' => 'Specific IPs' ],
+            [ 'value' => '2', 'label' => 'IP Range' ],
+        ];
+        return $_options;
+    }
+
+    public function toOptionHash() {
+        return [
+            '0' => 'Disabled',
+            '1' => 'Specific IPs', 
+            '2' => 'IP Range',
+        ];
+    }
+}

--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -1595,7 +1595,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><ip_filter>1</ip_filter></depends>
+                            <depends><ip_filter>2</ip_filter></depends>
                         </ip_filter_from>
                         <ip_filter_to>
                             <label>IP To</label>
@@ -1605,7 +1605,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends><ip_filter>1</ip_filter></depends>
+                            <depends><ip_filter>2</ip_filter></depends>
                         </ip_filter_to>
                         <allowspecific translate="label">
                             <label>Payment from applicable countries</label>

--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -1571,17 +1571,27 @@
                             <label>IP filter</label>
                             <tooltip>Enable IP filter let's you define an IP range when this payment method is visible</tooltip>
                             <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <source_model>adyen/source_POS_IpFilter</source_model>
                             <sort_order>57</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </ip_filter>
+                        <ip_filter_ips>
+                            <label>IPs</label>
+                            <frontend_type>text</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>58</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends><ip_filter>1</ip_filter></depends>
+                        </ip_filter_ips>
                         <ip_filter_from>
                             <label>IP From</label>
                             <frontend_type>text</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>58</sort_order>
+                            <sort_order>59</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -1591,7 +1601,7 @@
                             <label>IP To</label>
                             <frontend_type>text</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>59</sort_order>
+                            <sort_order>60</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
@@ -1600,7 +1610,7 @@
                         <allowspecific translate="label">
                             <label>Payment from applicable countries</label>
                             <frontend_type>allowspecific</frontend_type>
-                            <sort_order>60</sort_order>
+                            <sort_order>61</sort_order>
                             <source_model>adminhtml/system_config_source_payment_allspecificcountries</source_model>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>


### PR DESCRIPTION
The IP filter for POS payment method is only available by setting the IP range. 

However, sometime we need to set the discrete IP address, like 
"xx.xx.xx.xx,yyy.yyy.yyy.yyy"

This pull requests modify the "ip_filter" in system configuration, by adding one more method to set the IP whitelist. 