### PR TITLE
Add IPv6 support to IP Filters

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Data.php
+++ b/app/code/community/Adyen/Payment/Helper/Data.php
@@ -385,7 +385,7 @@ class Adyen_Payment_Helper_Data extends Mage_Payment_Helper_Data
 
 
     /**
-     * Is th IP in the given range
+     * Is the IPv4/v6 IP address in the given range
      * @param $ip
      * @param $from
      * @param $to
@@ -394,14 +394,33 @@ class Adyen_Payment_Helper_Data extends Mage_Payment_Helper_Data
      */
     public function ipInRange($ip, $from, $to)
     {
-        $ip = ip2long($ip);
-        $lowIp = ip2long($from);
-        $highIp = ip2long($to);
+        $ip = $this->getIpNumberFromAddress($ip);
+        $from = $this->getIpNumberFromAddress($from);
+        $to = $this->getIpNumberFromAddress($to);
 
-        if ($ip <= $highIp && $lowIp <= $ip) {
-            return true;
+        return (!$ip || !$from || !$to) ? false : ($ip <= $to && $from <= $ip);
+    }
+
+    /**
+     * Converts any given IPv4/v6 address to a string representation of it's 32/128bit integer
+     * which may be used for comparison
+     *
+     * @param string $address
+     * @return string|bool
+     */
+    public function getIpNumberFromAddress($address)
+    {
+        $pton = inet_pton($address);
+        if (!$pton) {
+            return false;
         }
-        return false;
+
+        $number = '';
+        foreach (unpack('C*', $pton) as $byte) {
+            $number .= str_pad(decbin($byte), 8, '0', STR_PAD_LEFT);
+        }
+
+        return base_convert(ltrim($number, '0'), 2, 10);
     }
 
 

--- a/app/code/community/Adyen/Payment/Helper/Data.php
+++ b/app/code/community/Adyen/Payment/Helper/Data.php
@@ -410,7 +410,8 @@ class Adyen_Payment_Helper_Data extends Mage_Payment_Helper_Data
      */
     public function getIpNumberFromAddress($address)
     {
-        $pton = inet_pton($address);
+        // Unrecognised addresses cause PHP warnings, silence the warning and return a bool instead
+        $pton = @inet_pton($address);
         if (!$pton) {
             return false;
         }


### PR DESCRIPTION
32bit PHP systems are incapable of representing a 128bit address (IPv6) in a 32bit integer (used by `ip2long`) so the current ipInRange method isn't compatible with IPv6 addresses.

This moves the ipInRange function over to using `inet_pton`, which represents the IP as a string instead (the `in_addr` representation of the given IP address). This function has been in PHP since 5.1.0 and has 7.x.x support, however on Windows systems it's only been compiled with the main binary since 5.3.0. This shouldn't be an issue since modern Magento distributions require PHP 5.4 as a minimum.