### PR TITLE
Credit card number length validation

### DIFF
--- a/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
@@ -49,7 +49,7 @@
     <li>
         <div class="input-box">
             <label for="<?php echo $_code ?>_cc_number"><?php echo Mage::helper('payment')->__('Credit Card Number') ?> <span class="required">*</span></label><br/>
-            <input type="text" pattern="[0-9]{14,}" id="<?php echo $_code ?>_cc_number" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]*" id="<?php echo $_code ?>_cc_number" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" maxlength="23"/>
             <?php if ($this->isCseEnabled()): ?>
                 <input type="hidden" id="payment_cc_type_cse" name="payment[cc_type]" />
                 <input type="hidden" id="payment_cc_number_cse" name="payment[cc_number]" />

--- a/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
@@ -49,7 +49,7 @@
     <li>
         <div class="input-box">
             <label for="<?php echo $_code ?>_cc_number"><?php echo Mage::helper('payment')->__('Credit Card Number') ?> <span class="required">*</span></label><br/>
-            <input type="text" pattern="[0-9]*" id="<?php echo $_code ?>_cc_number" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]{14,19}" id="<?php echo $_code ?>_cc_number" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" maxlength="23"/>
             <?php if ($this->isCseEnabled()): ?>
                 <input type="hidden" id="payment_cc_type_cse" name="payment[cc_type]" />
                 <input type="hidden" id="payment_cc_number_cse" name="payment[cc_number]" />
@@ -85,7 +85,7 @@
                 <label for="<?php echo $_code ?>_cc_cid"><?php echo Mage::helper('payment')->__('Card Verification Number') ?> <span class="required">*</span></label><br/>
 
                 <div class="v-fix">
-                    <input type="text" pattern="[0-9]*" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" maxlength="4" />
+                    <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" maxlength="4" />
                 </div>
             </div>
         </li>

--- a/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
@@ -49,7 +49,7 @@
     <li>
         <div class="input-box">
             <label for="<?php echo $_code ?>_cc_number"><?php echo Mage::helper('payment')->__('Credit Card Number') ?> <span class="required">*</span></label><br/>
-            <input type="text" pattern="[0-9]{14,19}" id="<?php echo $_code ?>_cc_number" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]{14,}" id="<?php echo $_code ?>_cc_number" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-number validate-cc-type" value="" maxlength="23"/>
             <?php if ($this->isCseEnabled()): ?>
                 <input type="hidden" id="payment_cc_type_cse" name="payment[cc_type]" />
                 <input type="hidden" id="payment_cc_number_cse" name="payment[cc_number]" />

--- a/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
@@ -85,7 +85,7 @@
                 <label for="<?php echo $_code ?>_cc_cid"><?php echo Mage::helper('payment')->__('Card Verification Number') ?> <span class="required">*</span></label><br/>
 
                 <div class="v-fix">
-                    <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" maxlength="4" />
+                    <input type="text" pattern="[0-9]{3,}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" maxlength="4" />
                 </div>
             </div>
         </li>

--- a/app/design/adminhtml/default/default/template/adyen/form/oneclick.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/oneclick.phtml
@@ -66,7 +66,7 @@
                 <label><?php echo $this->__('Card Verification Number') ?></label>
                 <?php if($this->hasVerification()): ?>
                     <div class="cvc_block" id="cvc_block_<?php echo $_code;?>">
-                        <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" />
+                        <input type="text" pattern="[0-9]{3,}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" />
                         <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
                     </div>
                 <?php endif; ?>

--- a/app/design/adminhtml/default/default/template/adyen/form/oneclick.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/oneclick.phtml
@@ -66,7 +66,7 @@
                 <label><?php echo $this->__('Card Verification Number') ?></label>
                 <?php if($this->hasVerification()): ?>
                     <div class="cvc_block" id="cvc_block_<?php echo $_code;?>">
-                        <input type="text" pattern="[0-9]*" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" />
+                        <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" />
                         <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
                     </div>
                 <?php endif; ?>

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -42,7 +42,7 @@ $_code = $this->getMethodCode();
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_number">
         <label for="creditCardNumber" class="required"><em>*</em><?php echo $this->__('Credit Card Number') ?></label>
         <div class="input-box">
-            <input type="text" pattern="[0-9]*" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]{14,19}" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
         </div>
     </li>
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_name">
@@ -79,7 +79,7 @@ $_code = $this->getMethodCode();
         <label id="<?php echo $_code ?>_cc_cid_label" for="<?php echo $_code ?>_cc_cid" class="required"><em id="<?php echo $_code ?>_cc_cid_label_em">*</em><?php echo $this->__('Card Verification Number') ?></label>
         <div class="input-box">
             <div class="v-fix">
-                <input type="text" pattern="[0-9]*" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-digits validate-length" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" size="7" maxlength="4" />
+                <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-digits validate-length" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" size="7" maxlength="4" />
             </div>
             <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
         </div>

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -42,7 +42,7 @@ $_code = $this->getMethodCode();
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_number">
         <label for="creditCardNumber" class="required"><em>*</em><?php echo $this->__('Credit Card Number') ?></label>
         <div class="input-box">
-            <input type="text" pattern="[0-9]{14,}" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]*" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
         </div>
     </li>
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_name">

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -79,7 +79,7 @@ $_code = $this->getMethodCode();
         <label id="<?php echo $_code ?>_cc_cid_label" for="<?php echo $_code ?>_cc_cid" class="required"><em id="<?php echo $_code ?>_cc_cid_label_em">*</em><?php echo $this->__('Card Verification Number') ?></label>
         <div class="input-box">
             <div class="v-fix">
-                <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-digits validate-length" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" size="7" maxlength="4" />
+                <input type="text" pattern="[0-9]{3,}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-digits validate-length" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" size="7" maxlength="4" />
             </div>
             <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
         </div>

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -42,7 +42,7 @@ $_code = $this->getMethodCode();
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_number">
         <label for="creditCardNumber" class="required"><em>*</em><?php echo $this->__('Credit Card Number') ?></label>
         <div class="input-box">
-            <input type="text" pattern="[0-9]{14,19}" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]{14,}" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
         </div>
     </li>
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_name">

--- a/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
@@ -75,7 +75,7 @@ $_recurringDetails = $this->getRecurringDetails();
                         <label><?php echo $this->__('Card Verification Number') ?></label>
                         <?php if($this->hasVerification()): ?>
                             <div class="cvc_block" id="cvc_block_<?php echo $_code;?>">
-                                <input type="text" pattern="[0-9]*" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry <?php echo $class; ?>" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" size="7" maxlength="<?php echo $maxLenght; ?>" />
+                                <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry <?php echo $class; ?>" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" size="7" maxlength="<?php echo $maxLenght; ?>" />
                                 <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
                             </div>
                         <?php endif; ?>

--- a/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
@@ -75,7 +75,7 @@ $_recurringDetails = $this->getRecurringDetails();
                         <label><?php echo $this->__('Card Verification Number') ?></label>
                         <?php if($this->hasVerification()): ?>
                             <div class="cvc_block" id="cvc_block_<?php echo $_code;?>">
-                                <input type="text" pattern="[0-9]{14,19}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry <?php echo $class; ?>" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" size="7" maxlength="<?php echo $maxLenght; ?>" />
+                                <input type="text" pattern="[0-9]{3,4}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry <?php echo $class; ?>" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" size="7" maxlength="<?php echo $maxLenght; ?>" />
                                 <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
                             </div>
                         <?php endif; ?>

--- a/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
@@ -75,7 +75,7 @@ $_recurringDetails = $this->getRecurringDetails();
                         <label><?php echo $this->__('Card Verification Number') ?></label>
                         <?php if($this->hasVerification()): ?>
                             <div class="cvc_block" id="cvc_block_<?php echo $_code;?>">
-                                <input type="text" pattern="[0-9]{3,4}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry <?php echo $class; ?>" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" size="7" maxlength="<?php echo $maxLenght; ?>" />
+                                <input type="text" pattern="[0-9]{3,}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry <?php echo $class; ?>" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[oneclick_cid_".$_code."]\"" : "data-encrypted-name-oneclick-" . $_code ."=cvc"); ?> value="" size="7" maxlength="<?php echo $maxLenght; ?>" />
                                 <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
                             </div>
                         <?php endif; ?>


### PR DESCRIPTION
@rikterbeek's latest merge added validation as a form of forcing mobile browsers to use numeric keyboards. As long as we're adding validation (numbers only), we may as well use it properly and validate against 14+ character for CC numbers and 3+ for CVV numbers. I would have gone with 14-19 characters for the credit card, but with the space adding javascript it was a bit more complicated.

We could reasonably change this to `14,22` to accommodate for 14,19 characters + 3 spaces.

Further improvements to: #710.