### PR TITLE
Allow safari users to scan credit cards

### DIFF
--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -48,14 +48,14 @@ $_code = $this->getMethodCode();
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_name">
         <label for="creditCardHolderName" class="required"><em>*</em><?php echo $this->__('Name on Card') ?></label>
         <div class="input-box">
-            <input type="text" title="<?php echo $this->__('Name on Card') ?>" class="input-text required-entry" id="creditCardHolderName" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_owner]\"" : "data-encrypted-name=\"holderName\""); ?> value="<?php echo $this->htmlEscape($this->getInfoData('cc_owner')) ?>" maxlength="100" />
+            <input type="text" title="<?php echo $this->__('Name on Card') ?>" class="input-text required-entry" autocomplete="cc-name" id="creditCardHolderName" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_owner]\"" : "data-encrypted-name=\"holderName\""); ?> value="<?php echo $this->htmlEscape($this->getInfoData('cc_owner')) ?>" maxlength="100" />
         </div>
     </li>
     <li class="adyen_payment_input_fields adyen_payment_input_fields_expiry">
         <label for="<?php echo $_code ?>_expiration" class="required"><em>*</em><?php echo $this->__('Expiration Date') ?></label>
         <div class="input-box">
             <div class="v-fix adyen_expiry_month">
-                <select id="<?php echo $_code ?>_expiration" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_exp_month]\"" : "data-encrypted-name=\"expiryMonth\""); ?> class="month validate-cc-exp required-entry">
+                <select id="<?php echo $_code ?>_expiration" autocomplete="cc-exp-month" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_exp_month]\"" : "data-encrypted-name=\"expiryMonth\""); ?> class="month validate-cc-exp required-entry">
                     <?php $_ccExpMonth = $this->getInfoData('cc_exp_month') ?>
                     <?php foreach ($this->getCcMonths() as $k=>$v): ?>
                         <option value="<?php echo $k?$k:'' ?>"<?php if($k==$_ccExpMonth): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
@@ -64,7 +64,7 @@ $_code = $this->getMethodCode();
             </div>
             <div class="v-fix adyen_expiry_year">
                 <?php $_ccExpYear = $this->getInfoData('cc_exp_year') ?>
-                <select id="<?php echo $_code ?>_expiration_yr" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_exp_year]\"" : "data-encrypted-name=\"expiryYear\""); ?> class="year required-entry">
+                <select id="<?php echo $_code ?>_expiration_yr" autocomplete="cc-exp-year" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_exp_year]\"" : "data-encrypted-name=\"expiryYear\""); ?> class="year required-entry">
                     <?php foreach ($this->getCcYears() as $k=>$v): ?>
                         <option value="<?php echo $k?$k:'' ?>"<?php if($k==$_ccExpYear): ?> selected="selected"<?php endif ?>><?php echo $v ?></option>
                     <?php endforeach ?>
@@ -79,7 +79,7 @@ $_code = $this->getMethodCode();
         <label id="<?php echo $_code ?>_cc_cid_label" for="<?php echo $_code ?>_cc_cid" class="required"><em id="<?php echo $_code ?>_cc_cid_label_em">*</em><?php echo $this->__('Card Verification Number') ?></label>
         <div class="input-box">
             <div class="v-fix">
-                <input type="text" pattern="[0-9]{3,}" title="<?php echo $this->__('Card Verification Number') ?>" class="input-text cvv required-entry validate-digits validate-length" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" size="7" maxlength="4" />
+                <input type="text" pattern="[0-9]{3,}" title="<?php echo $this->__('Card Verification Number') ?>" autocomplete="cc-csc" class="input-text cvv required-entry validate-digits validate-length" id="<?php echo $_code ?>_cc_cid" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_cid]\"" : "data-encrypted-name=\"cvc\""); ?> value="" size="7" maxlength="4" />
             </div>
             <a href="#" class="cvv-what-is-this"><?php echo $this->__('What is this?') ?></a>
         </div>

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -42,7 +42,7 @@ $_code = $this->getMethodCode();
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_number">
         <label for="creditCardNumber" class="required"><em>*</em><?php echo $this->__('Credit Card Number') ?></label>
         <div class="input-box">
-            <input type="text" pattern="[0-9]*" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
+            <input type="text" pattern="[0-9]*" autocomplete="cc-number" id="creditCardNumber" <?php echo (!$this->isCseEnabled() ? "name=\"payment[cc_number]\"" : " data-encrypted-name=\"number\""); ?> title="<?php echo $this->__('Credit Card Number') ?>" class="input-text validate-cc-type required-entry" value="" maxlength="23"/>
         </div>
     </li>
     <li class="adyen_payment_input_fields adyen_payment_input_fields_cc_name">


### PR DESCRIPTION
On Safari, if an input field has the autocomplete="cc-number" attribute and is on a secure connection, then Safari will recognize it as an creditcard field and offer autocomplete and a card scanner.