### PR TITLE
Fixes "can't use method return value in write context" fatal error in…

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Sepa.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Sepa.php
@@ -83,7 +83,8 @@ class Adyen_Payment_Model_Adyen_Sepa extends Adyen_Payment_Model_Adyen_Abstract
 
         if($ibanValidation) {
 
-            if(!$this->validateIban($info->getAdditionalInformation('iban')) || empty($info->getAdditionalInformation('iban'))){
+            $iban = $info->getAdditionalInformation('iban');
+            if(!$this->validateIban($iban) || empty($iban)){
                 $errorCode = 'invalid_data';
                 $errorMsg = Mage::helper('adyen')->__('Invalid Iban number.');
                 Mage::throwException($errorMsg);


### PR DESCRIPTION
… PHP 5.4.x (PHP versions below 5.5 do not support references to temporary values returned from functions)