### PR TITLE
Fixed a malformed if else

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Payment.php
+++ b/app/code/community/Adyen/Payment/Helper/Payment.php
@@ -446,15 +446,21 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
             // the following allows to send the 'pretty' customer ID or increment ID to Adyen instead of the entity id
             // used collection here, it's about half the resources of using the load method on the customer opject
             /* var $customer Mage_Customer_Model_Resource_Customer_Collection */
-            $customer = Mage::getResourceModel('customer/customer_collection')
+            $collection = Mage::getResourceModel('customer/customer_collection')
                 ->addAttributeToSelect('adyen_customer_ref')
                 ->addAttributeToSelect('increment_id')
-                ->addAttributeToFilter('entity_id', $customerId)
-                ->getFirstItem();
+                ->addAttributeToFilter('entity_id', $customerId);
+            $collection->getSelect()->limit(1);
+            $customer = $collection->getFirstItem();
 
-            $customerId = $customer->getId() && $customer->getData('adyen_customer_ref') ?
-                $customer->getData('increment_id') :
-                $customerId;
+            if ($customer->getData('adyen_customer_ref')) {
+               $customerId = $customer->getData('adyen_customer_ref');
+            } elsef ($customer->getData('increment_id')) {
+               $customerId = $customer->getData('increment_id');
+            } else {
+               $customerId = $customer->getId();
+            }
+            
             return $customerId;
         } else { // it was a guest order
             $customerId = self::GUEST_ID . $realOrderId;

--- a/app/code/community/Adyen/Payment/Model/Adyen/Data/PaymentRequest.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Data/PaymentRequest.php
@@ -77,15 +77,9 @@ class Adyen_Payment_Model_Adyen_Data_PaymentRequest extends Adyen_Payment_Model_
         $orderCurrencyCode = $order->getOrderCurrencyCode();
         // override amount because this amount uses the right currency
 
-        $customerId = $order->getCustomerId();
-        if ($customerId) {
-            $customer = Mage::getModel('customer/customer')->load($order->getCustomerId());
-            $customerId = $customer->getData('adyen_customer_ref')
-                ?: $customer->getData('increment_id')
-                ?: $customerId;
-        }
-
         $realOrderId = $order->getRealOrderId();
+		
+		$customerId = Mage::helper('adyen/payment')->getShopperReference($order->getCustomerId(), $realOrderId);
 
         $this->reference = $incrementId;
         $this->merchantAccount = $merchantAccount;

--- a/shell/adyen.php
+++ b/shell/adyen.php
@@ -114,7 +114,13 @@ class Adyen_Payments_Shell extends Mage_Shell_Abstract
 			$customerReferences = $customerCollection->getConnection()->fetchAssoc($select);
 			foreach ($customerReferences as $customerId => $customerData) {
 
-				$customerReference = $customerData['increment_id'] ;
+				if ($customerData['adyen_customer_ref']) {
+				   $customerReference = $customerData['adyen_customer_ref'];
+				} elsef ($customerData['increment_id']) {
+				   $customerReference = $customerData['increment_id'];
+				} else {
+				   $customerReference = customerId;
+				}
 
 				$recurringContracts = $api->listRecurringContracts($customerReference, $store);
                 echo sprintf("Found %s recurring contracts for customer %s (ref. %s)\n", count($recurringContracts), $customerId, $customerReference);

--- a/shell/adyen.php
+++ b/shell/adyen.php
@@ -114,9 +114,7 @@ class Adyen_Payments_Shell extends Mage_Shell_Abstract
 			$customerReferences = $customerCollection->getConnection()->fetchAssoc($select);
 			foreach ($customerReferences as $customerId => $customerData) {
 
-				$customerReference = $customerData['adyen_customer_ref'] ?
-				   $customerData['increment_id'] :
-				   $customerId ;
+				$customerReference = $customerData['increment_id'] ;
 
 				$recurringContracts = $api->listRecurringContracts($customerReference, $store);
                 echo sprintf("Found %s recurring contracts for customer %s (ref. %s)\n", count($recurringContracts), $customerId, $customerReference);

--- a/shell/adyen.php
+++ b/shell/adyen.php
@@ -114,9 +114,9 @@ class Adyen_Payments_Shell extends Mage_Shell_Abstract
 			$customerReferences = $customerCollection->getConnection()->fetchAssoc($select);
 			foreach ($customerReferences as $customerId => $customerData) {
 
-				$customerReference = $customerData['adyen_customer_ref']
-						?: $customerData['increment_id']
-						?: $customerId;
+				$customerReference = $customerData['adyen_customer_ref'] ?
+				   $customerData['increment_id'] :
+				   $customerId ;
 
 				$recurringContracts = $api->listRecurringContracts($customerReference, $store);
                 echo sprintf("Found %s recurring contracts for customer %s (ref. %s)\n", count($recurringContracts), $customerId, $customerReference);


### PR DESCRIPTION
Cause 

```
$customerReference = $customerData['adyen_customer_ref']
						?: $customerData['increment_id']
						?: $customerId;
```

would never have worked