### PR TITLE
Check for Hold state, unhold when it is.

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -982,10 +982,16 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract {
     {
         $this->_debugData[$this->_count]['_createInvoice'] = 'Creating invoice for order';
 
-        //Set order state to new because with order state payment_review it is not possible to create an invoice
+        // Set order state to new because with order state payment_review it is not possible to create an invoice
         if (strcmp($order->getState(), Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW) == 0) {
             $order->setState(Mage_Sales_Model_Order::STATE_NEW);
         }
+        
+        // Check to see if the order is in the "Hold" state, and unhold when it is.
+        if ($order->canUnhold()) {
+	        $order->unhold();
+            $order->save();
+        }        
 
         if ($order->canInvoice()) {
 


### PR DESCRIPTION
Check for Hold state, unhold when it is. This will resolve the issue for the situation in the screenshot. First we get a cancelled notification and the order is pushed into the "Hold" state. When we later receive an authorisation notification this change will check if the order is on the hold state and unhold it first before creating the invoice.

![image](https://user-images.githubusercontent.com/1058480/29869565-bc052984-8d83-11e7-94c9-ec01ccbb27b2.png)
