### PR TITLE
Skip order cancellation if it's previously authorised

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -963,19 +963,18 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract {
         return $this->_getConfigData('fraud_manual_review_accept_status', 'adyen_abstract', $order->getStoreId());
     }
 
-    protected function _isTotalAmount($orderAmount) {
-
+    protected function _isTotalAmount($orderAmount)
+    {
         $this->_debugData[$this->_count]['_isTotalAmount'] = 'Validate if AUTHORISATION notification has the total amount of the order';
         $value = (int)$this->_value;
 
-        if($value == $orderAmount) {
+        if($value >= $orderAmount) {
             $this->_debugData[$this->_count]['_isTotalAmount result'] = 'AUTHORISATION has the full amount';
             return true;
         } else {
             $this->_debugData[$this->_count]['_isTotalAmount result'] = 'This is a partial AUTHORISATION, the amount is ' . $this->_value;
             return false;
         }
-
     }
 
     /**

--- a/app/code/community/Adyen/Payment/controllers/ProcessController.php
+++ b/app/code/community/Adyen/Payment/controllers/ProcessController.php
@@ -343,6 +343,13 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action 
 
         $order->loadByIncrementId($incrementId);
 
+        // Don't cancel if the order had been authorised
+        if($order->getAdyenEventCode() == Adyen_Payment_Model_Event::ADYEN_EVENT_AUTHORISED) {
+            $session->addError($this->__('Your payment has been already processed'));
+            $this->_redirectCheckoutCart();
+            return;
+        }
+
         // reactivate the quote again
         $quoteId = $order->getQuoteId();
         $quote = Mage::getModel('sales/quote')


### PR DESCRIPTION
**Description**
1. Skip order cancellation if it's previously authorised
2. Consider an order fully paid if the authorised amount is at least the order's total amount

**Tested scenarios**
Tested HPP flow of authResult = CANCELLED and then authResult = AUTHORISED
