### PR TITLE
Populate payment methods from payment helper

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Payment/Data.php
+++ b/app/code/community/Adyen/Payment/Helper/Payment/Data.php
@@ -123,4 +123,15 @@ class Adyen_Payment_Helper_Payment_Data extends Mage_Payment_Helper_Data {
         $block->setInfo($info);
         return $block;
     }
+
+    public function getPaymentMethods($store = null)
+    {
+        $observer = new Adyen_Payment_Model_Observer();
+        $billingAgreementObserver = new Adyen_Payment_Model_Billing_Agreement_Observer();
+
+        $observer->addMethodsToConfig(null);
+        $billingAgreementObserver->addMethodsToConfig(null);
+
+        return parent::getPaymentMethods($store);
+    }
 }

--- a/app/code/community/Adyen/Payment/Model/Observer.php
+++ b/app/code/community/Adyen/Payment/Model/Observer.php
@@ -37,10 +37,10 @@ class Adyen_Payment_Model_Observer {
             $store = Mage::app()->getStore();
         }
 
-        // by default disable adyen_ideal only if IDeal is in directoryLookup result show this payment method
-        $store->setConfig('payment/adyen_ideal/active', 0);
-
         if (Mage::getStoreConfigFlag('payment/adyen_hpp/active', $store)) {
+            // by default disable adyen_ideal only if IDeal is in directoryLookup result show this payment method
+            $store->setConfig('payment/adyen_ideal/active', 0);
+
             try {
                 $this->_addHppMethodsToConfig($store);
             } catch (Exception $e) {

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -151,78 +151,6 @@
                     </adyen_payment_capture>
                 </observers>
             </sales_order_payment_capture>
-            <controller_action_predispatch_checkout>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_checkout>
-            <controller_action_predispatch_firecheckout>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_firecheckout>
-            <controller_action_predispatch_onestepcheckout>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_onestepcheckout>
-            <controller_action_predispatch_opc>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_opc>
-            <controller_action_predispatch_streamcheckout>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_streamcheckout>
-            <controller_action_predispatch_gomage_checkout>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_gomage_checkout>
             <sales_order_shipment_save_before>
                 <observers>
                     <adyen_payment_capture_invoice_on_shipment>
@@ -294,18 +222,6 @@
             </modules>
         </translate>
         <events>
-            <controller_action_predispatch_adminhtml>
-                <observers>
-                    <adyen_payment_hpp>
-                        <class>adyen/observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_hpp>
-                    <adyen_payment_billing_agreement>
-                        <class>adyen/billing_agreement_observer</class>
-                        <method>addMethodsToConfig</method>
-                    </adyen_payment_billing_agreement>
-                </observers>
-            </controller_action_predispatch_adminhtml>
             <sales_order_payment_cancel>
                 <observers>
                     <adyen_payment>


### PR DESCRIPTION
**Description**
Populate payment methods from payment helper.
Fixes interferences with 3rd party (checkout) modules and removes the observer invocation.

**Tested scenarios**
Frontend/backend payment
