### PR TITLE
Remove Magento country restriction for showing iDeal

### DIFF
--- a/app/code/community/Adyen/Payment/data/adyen_setup/data-upgrade-2.9.4-2.9.4.1.php
+++ b/app/code/community/Adyen/Payment/data/adyen_setup/data-upgrade-2.9.4-2.9.4.1.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Adyen Payment Module
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * @category	Adyen
+ * @package	Adyen_Payment
+ * @copyright	Copyright (c) 2011 Adyen (http://www.adyen.com)
+ * @license	http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+/**
+ * @category   Payment Gateway
+ * @package    Adyen_Payment
+ * @author     Adyen
+ * @property   Adyen B.V
+ * @copyright  Copyright (c) 2014 Adyen BV (http://www.adyen.com)
+ */
+
+
+/*
+ * clear the field payment/adyen_ideal/allowspecific because this is not a setting anymore
+ */
+
+$path = "payment/adyen_ideal/allowspecific";
+
+try {
+    $collection = Mage::getModel('core/config_data')->getCollection()
+        ->addFieldToFilter('path', array('like' => $path ));
+
+    if ($collection->count() > 0) {
+        foreach ($collection as $coreConfig) {
+            $coreConfig->setValue('0')->save();
+        }
+    }
+} catch (Exception $e) {
+    Mage::log($e->getMessage(), Zend_Log::ERR);
+}

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -373,8 +373,7 @@
                 <show_ideal_logos>0</show_ideal_logos>
                 <autoselect_stored_ideal_bank>1</autoselect_stored_ideal_bank>
                 <sort_order>35</sort_order>
-                <allowspecific>1</allowspecific>
-                <specificcountry>NL</specificcountry>
+                <allowspecific>0</allowspecific>
             </adyen_ideal>
             <adyen_pos translate="title" module="adyen">
                 <active>0</active>


### PR DESCRIPTION
**Description**
Removed Magento country restriction for showing iDeal, so that it will show up as long as it is returned from directory lookup.

**Tested scenarios**
Checkout with NL, BE (ideal configured in skin), DE (ideal not configured)
