### PR TITLE
Fixes

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -570,7 +570,7 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract {
                     // set billing agreement data
                     $payment->setBillingAgreementData(array(
                         'billing_agreement_id'  => $recurringDetailReference,
-                        'method_code'           => $payment->getMethodCode()
+                        'method_code'           => $_paymentCode
                     ));
 
                     // create billing agreement for this order


### PR DESCRIPTION
**Description**
$payment->getMethodCode() does not exit, it is always null, we use either $_paymentCode or $payment->getMethod()

**Tested scenarios**
When receives the event: RECURRING_CONTRACT

**Fixed issue**:
N/A