### PR TITLE
Don't send deliveryAddress to HPP if it is not set

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Payment.php
+++ b/app/code/community/Adyen/Payment/Helper/Payment.php
@@ -369,7 +369,7 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
 
     public function explodeArrayToRequestFields($adyFields, $name, $items)
     {
-        if (!empty($items) && is_array($items)) {
+        if (is_array($items)) {
             foreach ($items as $field => $value) {
                 $adyFields[$name . '.' . $field] = $value;
             }
@@ -561,12 +561,12 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
     public function getHppBillingAddressDetails($billingAddress)
     {
         $billingAddressRequest = [
-            'street' => 'NA',
-            'houseNumberOrName' => 'NA',
-            'city' => 'NA',
-            'postalCode' => 'NA',
-            'stateOrProvince' => 'NA',
-            'country' => 'NA'
+            'street' => 'N/A',
+            'houseNumberOrName' => 'N/A',
+            'city' => 'N/A',
+            'postalCode' => 'N/A',
+            'stateOrProvince' => 'N/A',
+            'country' => 'N/A'
         ];
 
         if(trim($this->getStreet($billingAddress,true)->getName()) != "") {
@@ -608,16 +608,16 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
     public function getHppDeliveryAddressDetails($deliveryAddress)
     {
         // Gift Cards and downloadable products don't have delivery addresses
-        if (!$deliveryAddress) {
+        if (!is_object($deliveryAddress)) {
             return null;
         }
 
         $deliveryAddressRequest = [
-            'street' => 'NA',
-            'houseNumberOrName' => 'NA',
-            'city' => 'NA',
-            'postalCode' => 'NA',
-            'stateOrProvince' => 'NA',
+            'street' => 'N/A',
+            'houseNumberOrName' => 'N/A',
+            'city' => 'N/A',
+            'postalCode' => 'N/A',
+            'stateOrProvince' => 'N/A',
             'country' => 'N/A'
         ];
 

--- a/app/code/community/Adyen/Payment/Helper/Payment.php
+++ b/app/code/community/Adyen/Payment/Helper/Payment.php
@@ -369,7 +369,7 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
 
     public function explodeArrayToRequestFields($adyFields, $name, $items)
     {
-        if (is_array($items)) {
+        if (!empty($items) && is_array($items)) {
             foreach ($items as $field => $value) {
                 $adyFields[$name . '.' . $field] = $value;
             }
@@ -607,9 +607,9 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
      */
     public function getHppDeliveryAddressDetails($deliveryAddress)
     {
-        if (!is_object($deliveryAddress)) {
-            // Gift Cards don't have delivery addresses, this prevents member function calls on non-object errors
-            return $deliveryAddress;
+        // Gift Cards and downloadable products don't have delivery addresses
+        if (!$deliveryAddress) {
+            return null;
         }
 
         $deliveryAddressRequest = [

--- a/app/code/community/Adyen/Payment/Helper/Payment.php
+++ b/app/code/community/Adyen/Payment/Helper/Payment.php
@@ -178,12 +178,11 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
         $billingAddressType = $viewDetails['billing_address_type'];
         $deliveryAddressType = $viewDetails['shipping_address_type'];
         $shopperType = $viewDetails['customer_info'];
-        
+
         // set Shopper, Billing and DeliveryAddress
         $shopperInfo =  $this->getHppShopperDetails($order->getBillingAddress(), $order->getCustomerGender(), $order->getCustomerDob());
         $billingAddress = $this->getHppBillingAddressDetails($order->getBillingAddress());
         $deliveryAddress = $this->getHppDeliveryAddressDetails($order->getShippingAddress());
-
         $openInvoiceData = $this->getOpenInvoiceData($incrementId, $order);
         
 
@@ -608,19 +607,19 @@ class Adyen_Payment_Helper_Payment extends Adyen_Payment_Helper_Data
      */
     public function getHppDeliveryAddressDetails($deliveryAddress)
     {
+        if (!is_object($deliveryAddress)) {
+            // Gift Cards don't have delivery addresses, this prevents member function calls on non-object errors
+            return $deliveryAddress;
+        }
+
         $deliveryAddressRequest = [
             'street' => 'NA',
             'houseNumberOrName' => 'NA',
             'city' => 'NA',
             'postalCode' => 'NA',
             'stateOrProvince' => 'NA',
-            'country' => 'NA'
+            'country' => 'N/A'
         ];
-
-        if (!is_object($deliveryAddress)) {
-            // Gift Cards don't have delivery addresses, this prevents member function calls on non-object errors
-            return $deliveryAddressRequest;
-        }
 
         if(trim($this->getStreet($deliveryAddress,true)->getName() != "")) {
             $deliveryAddressRequest['street'] = trim($this->getStreet($deliveryAddress,true)->getName());


### PR DESCRIPTION
**Description**
Do not send the deliveryAddress in the request if it is empty. For example for downloadable products there is no delivery address.

**Tested scenarios**
Shopping cart with only downloadable products -> deliveryAddress not set in request
Shopping cart with downloadable products and normal products -> deliveryAddress set in request
Shopping cart with only normal products -> deliveryAddress set in request
