### PR TITLE
Adyen Payment PHP 7 compatibility

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Payment/Data.php
+++ b/app/code/community/Adyen/Payment/Helper/Payment/Data.php
@@ -129,8 +129,8 @@ class Adyen_Payment_Helper_Payment_Data extends Mage_Payment_Helper_Data {
         $observer = new Adyen_Payment_Model_Observer();
         $billingAgreementObserver = new Adyen_Payment_Model_Billing_Agreement_Observer();
 
-        $observer->addMethodsToConfig(null);
-        $billingAgreementObserver->addMethodsToConfig(null);
+        $observer->addMethodsToConfig(new Varien_Event_Observer());
+        $billingAgreementObserver->addMethodsToConfig(new Varien_Event_Observer());
 
         return parent::getPaymentMethods($store);
     }


### PR DESCRIPTION
**Description**
In the function "addMethodsToConfig" the first parameter is expected to be a Varien_Event_Observer. In PHP 5 it is possible to pass null to this parameter. In PHP 7 this is not possible anymore.

Solution to this issue, Pass an empty Varien_Event_Observer as parameter since no where in the function is checked on null, no behavior will change.

**Fixed issue**:  Adyen Payment not compatible with PHP 7