### PR TITLE
+: Only sent order mail when entire order is paid

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -840,7 +840,7 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract
         $_paymentCode = $this->_paymentMethodCode($order);
 
         // for boleto and multibanco confirmation mail is send on order creation
-        if (!in_array($payment_method, array('adyen_boleto', 'adyen_multibanco'))) {
+        if (!in_array($payment_method, array('adyen_boleto', 'adyen_multibanco')) && round($order->getBaseGrandTotal(), 2) == round($order->getBaseTotalPaid(), 2)) {
             // send order confirmation mail after invoice creation so merchant can add invoicePDF to this mail
             $order->sendNewOrderEmail(); // send order email
         }


### PR DESCRIPTION
**Description**
For orders partially paid with Fashioncheque, two order success mails were sent.
One when the feedback about the Fashioncheque payment is processed
A second one when the ideal (in our case) payment is processed

I've added a check to see if entire order is paid before sending order mail

**Tested scenarios**
Processed queue items and checked if mail is sent

