### PR TITLE
Check notification mode as boolean instead of string

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/ProcessController.php
+++ b/app/code/community/Adyen/Payment/controllers/ProcessController.php
@@ -487,10 +487,9 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action
     {
         try {
             $notificationItems = json_decode(file_get_contents('php://input'), true);
-
             $notificationMode = isset($notificationItems['live']) ? $notificationItems['live'] : "";
 
-            if ($notificationMode != "" && $this->_validateNotificationMode($notificationMode)) {
+            if ($notificationMode !== "" && $this->_validateNotificationMode($notificationMode)) {
                 foreach ($notificationItems['notificationItems'] as $notificationItem) {
                     $result = $this->processNotification($notificationItem['NotificationRequestItem']);
                        if (!empty($result['response']) && $result['response'] == "401") {
@@ -604,7 +603,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action
     protected function _validateNotificationMode($notificationMode)
     {
         $mode = $this->_getConfigData('demoMode');
-        if ($mode == 'Y' && $notificationMode == "false" || $mode == 'N' && $notificationMode == 'true') {
+        if ($mode == 'Y' && $notificationMode == false || $mode == 'N' && $notificationMode == true) {
             return true;
         }
         return false;


### PR DESCRIPTION
**Description**
The "Standard Notification" API in the [Server Communication Settings](https://ca-test.adyen.com/ca/ca/config/showthirdparty.shtml) uses this format for the JSON payload:
```JSON Request JSON sent:
{"live":false,"notificationItems":[{"...
```
The "live" property comes over as a boolean `false`.  However, the method `_validateNotificationMode` checks it as a string, and incorrectly returns `false` every time, resulting in a 401 result when running "Test Configuration".

**Tested scenarios**
Run "Test Configuration" from the notification server communication in the Adyen backend.  If the account is set to live:false and the Magento module is in demo mode, the test should succeed.
