### PR TITLE
PW-515: Added fix for Test Notifications

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/ProcessController.php
+++ b/app/code/community/Adyen/Payment/controllers/ProcessController.php
@@ -434,7 +434,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action
 
             $notificationMode = isset($response['live']) ? $response['live'] : "";
 
-            if ($notificationMode != "" && $this->_validateNotificationMode($notificationMode)) {
+            if ($notificationMode != "" || $notificationMode !== "" && $this->_validateNotificationMode($notificationMode)) {
                 // add HTTP POST attributes as an array so it is the same as JSON and SOAP result
                 foreach ($response as $key => $value) {
                     if (strpos($key, '_') !== false) {
@@ -490,7 +490,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action
 
             $notificationMode = isset($notificationItems['live']) ? $notificationItems['live'] : "";
 
-            if ($notificationMode != "" && $this->_validateNotificationMode($notificationMode)) {
+            if ($notificationMode != "" || $notificationMode !== "" && $this->_validateNotificationMode($notificationMode)) {
                 foreach ($notificationItems['notificationItems'] as $notificationItem) {
                     $result = $this->processNotification($notificationItem['NotificationRequestItem']);
                        if (!empty($result['response']) && $result['response'] == "401") {
@@ -604,7 +604,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action
     protected function _validateNotificationMode($notificationMode)
     {
         $mode = $this->_getConfigData('demoMode');
-        if ($mode == 'Y' && $notificationMode == "false" || $mode == 'N' && $notificationMode == 'true') {
+        if ($mode == 'Y' && ($notificationMode == "false" || $notificationMode == false) || $mode == 'N' && ($notificationMode == 'true' || $notificationMode == true)) {
             return true;
         }
         return false;


### PR DESCRIPTION
**Description**
On test notifications, the field "live" is a boolean instead of a string.
A check has been added so that we cover both cases.