### PR TITLE
added shell process to run updateNotificationQueue(), removed Magento…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ But you can also request or suggest new features or code changes yourself!
 </ul>
 
 <h2>Setup Cron</h2>
-It is needed to enable the Magento cron. Make sure that this is running every minute.
-We are using a cronjob to process the notifications. The cronjob will be executed every minute. It only executes the notifications that have been received at least 5 minutes ago. We have built in this 5 minutes so we are sure Magento has created the order and all save after events are executed.
-A handy tool to get into your cronjobs is AOE scheduler. You can download this tool through <a href="http://www.magentocommerce.com/magento-connect/aoe-scheduler.html" target="_blank">Magento Connect</a> or <a target="_blank" href="https://github.com/AOEpeople/Aoe_Scheduler/releases">GitHub</a>
+Adyen notifications and payment updates are handled periodically every minute by the system cron process. The Adyen shell process can be configured by adding the following to your crontab. Edit accordingly, and replace `/var/www/html` with the web root of your Magento store. 
+
+<code>
+* * * * * /usr/bin/flock -n ~/.adyen_notification_mage.lock /usr/bin/php -f /var/www/html/shell/adyen.php -- -action updateNotificationQueue >> /var/www/html/var/log/adyen_notification_cron.log
+</code>
 
 <h2>Support</h2>
 You can create issues on our Magento Repository or if you have some specific problems for your account you can contact <a href="mailto:magento@adyen.com">magento@adyen.com</a>  as well.

--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -1285,7 +1285,10 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract
             $this->_debugData[$this->_count]['_setPaymentAuthorized selected status'] = 'The status that is selected is:' . $status;
 
             // set the state to processing
-            $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING);
+            // if state is pending - do not change holded orders
+            if($order->getState() == 'pending') {
+              $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING);
+            }
         }
 
         // virtual order can have different status

--- a/app/code/community/Adyen/Payment/controllers/ApplePayController.php
+++ b/app/code/community/Adyen/Payment/controllers/ApplePayController.php
@@ -67,6 +67,7 @@ class Adyen_Payment_ApplePayController extends Mage_Core_Controller_Front_Action
                 'Content-Type: application/json',
                 'Content-Length: ' . strlen($data))
         );
+        curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1); 
 
         $result = curl_exec($ch);
         $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -101,28 +102,29 @@ class Adyen_Payment_ApplePayController extends Mage_Core_Controller_Front_Action
         $params = $this->getRequest()->getParams();
 
         // allow empty parameters because this can happen if you have an invalid address in wallet on phone
+        $country = "";
         if(isset($params['country'])) {
-            $country = $params['country'];
-        } else {
-            $country = "";
+            $country = strtoupper($params['country']);
         }
 
+        $zipcode = "";
         if(isset($params['zipcode'])) {
-            $zipcode = $params['zipcode'];
-        } else {
-            $zipcode = "";
+            $zipcode = trim($params['zipcode']);
+            // ApplePay only provides the 1st part of a UK postcode.
+            // add a dummy 2nd part for correct postcode rate matching 
+            if($country == 'GB') {
+              $zipcode .= ' 5EZ';
+            }
         }
 
+        $productId = "";
         if(isset($params['productId'])) {
             $productId = $params['productId'];
-        } else {
-            $productId = "";
         }
 
+        $qty = 1;
         if(isset($params['qty'])) {
             $qty = $params['qty'];
-        } else {
-            $qty = 1;
         }
 
         // is it from the cart or from a product ??
@@ -155,15 +157,38 @@ class Adyen_Payment_ApplePayController extends Mage_Core_Controller_Front_Action
             $rates = $address->collectShippingRates()
                 ->getGroupedAllShippingRates();
 
+            // Refresh totals - they might have changed with new address/tax
+            $totals = $cart->getQuote()->getTotals();
+            $config = Mage::getSingleton('tax/config');
+
+            $total = 0;
+            if(isset($totals['grand_total']) && $totals['grand_total']->getValue()) {
+              $total = $totals["grand_total"]->getValue();
+            }
+
             $costs = array();
             foreach ($rates as $carrier) {
                 foreach ($carrier as $rate) {
-                    $costs[] = array(
-                        'label' => trim($rate->getCarrierTitle()),
+
+                    // get shipping with correct tax applied, convert to correct currency for store/customer & strip currency symbols.
+                    $shipping_amount = Mage::helper('tax')->getShippingPrice($rate->getPrice(), true, $address);
+                    $shipping_amount = Mage::helper('core')->currency($shipping_amount,$format=true,$incContainer=false); 
+                    $shipping_amount = FILTER_VAR($shipping_amount, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION);
+
+                    $cost = new Varien_Object(array(
+                        'label' => trim($rate->getMethodTitle()),
                         'detail' => '',
-                        'amount' => $rate->getPrice(),
-                        'identifier' => $rate->getCode()
-                    );
+                        'amount' => $shipping_amount,
+                        'identifier' => $rate->getCode(),
+                        // refresh total with inclusive/exclusive tax
+                        // may have changed with new address
+                        'total' => $total,
+                        'subtotal' => $total - $shipping_amount,
+                    ));
+                    // allow shipping method to be updated by 3rd party extension
+                    // e.g. stores/ developers may want to update label
+                    Mage::dispatchEvent('adyen_apple_pay_shipping_rate_init', array('cost'=>$cost, 'rate'=> $rate, 'address'=>$address));
+                    $costs[] = $cost->toArray();
                 }
             }
         }
@@ -235,7 +260,7 @@ class Adyen_Payment_ApplePayController extends Mage_Core_Controller_Front_Action
         }
 
         $qty = $params['qty'];
-        $shippingMethod = $params['shippingMethod'];
+        $shippingMethod = isset($params['shippingMethod']) ? $params['shippingMethod'] : null;
         $payment = json_decode($params['payment']);
 
 

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -495,6 +495,7 @@
                 <title>Adyen Apple Pay</title>
                 <sort_order>80</sort_order>
                 <shipping_type>shipping</shipping_type>
+                <require_shipping>1</require_shipping>
                 <allow_quest_checkout>1</allow_quest_checkout>
                 <change_address>1</change_address>
                 <show_in_payment_step_checkout>1</show_in_payment_step_checkout>

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -655,6 +655,7 @@
             </payment>
         </adyen>
     </default>
+    <!--
     <crontab>
         <jobs>
             <adyen_payment_process_notification_queue>
@@ -667,4 +668,5 @@
             </adyen_payment_process_notification_queue>
         </jobs>
     </crontab>
+    -->
 </config>

--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -1988,6 +1988,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </shipping_type>
+                        <require_shipping>
+                            <label>Require Shipping</label>
+                            <tooltip>Require customer to select a valid shipping method to complete order.</tooltip>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>51</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </require_shipping>
                         <allow_quest_checkout>
                             <label>Allow Guest Checkout</label>
                             <tooltip>Show Apple Pay icon if user is not logged in. The user has the option to set his own contact details and shipping\billing address.</tooltip>

--- a/app/design/frontend/base/default/template/adyen/apple_pay.phtml
+++ b/app/design/frontend/base/default/template/adyen/apple_pay.phtml
@@ -186,7 +186,7 @@ if ($this->hasApplePayEnabled()):
 
             var paymentRequest = {
                 currencyCode: "<?php echo $currency; ?>",
-                countryCode: "US",
+                countryCode: "<?php echo $this->getShippingCountry(); ?>",
                 total: {
                     label: "<?php echo $productTitle; ?>",
                     amount: window.AdyenApplePayTotalAmount
@@ -252,18 +252,34 @@ if ($this->hasApplePayEnabled()):
                 var promise = retrieveShippingMethods(shippingContract.countryCode, shippingContract.postalCode);
                 promise.then(function (shippingMethods) {
 
-                    if(shippingMethods.length > 0){
-                        var status = session.STATUS_SUCCESS;
-                        var newTotal = {
+                    var status = session.STATUS_SUCCESS;
+                    var newTotal = {
+                        label: "<?php echo $productTitle; ?>",
+                        amount: amount
+                    };
+
+                    var newLineItems = [
+                        {
+                            type: "final",
                             label: "<?php echo $productTitle; ?>",
-                            amount: amount + shippingMethods[0].amount
+                            amount: amount
+                        }
+                    ];
+
+                    if(shippingMethods.length > 0){
+
+                        status = session.STATUS_SUCCESS;
+
+                        newTotal = {
+                            label: "<?php echo $productTitle; ?>",
+                            amount: shippingMethods[0].total
                         };
 
-                        var newLineItems = [
+                        newLineItems = [
                             {
                                 type: "final",
                                 label: "<?php echo $this->__('subtotal') ?>",
-                                amount: amount
+                                amount: shippingMethods[0].subtotal
                             },
                             {
                                 type: "final",
@@ -276,20 +292,11 @@ if ($this->hasApplePayEnabled()):
                         // set the shippingMethod
                         window.AdyenApplePayShippingMethodIdentifier = shippingMethods[0].identifier;
                     } else {
-                        var status = session.STATUS_SUCCESS;
-                        var newTotal = {
-                            label: "<?php echo $productTitle; ?>",
-                            amount: amount
-                        };
-
-                        var newLineItems = [
-                            {
-                                type: "final",
-                                label: "<?php echo $productTitle; ?>",
-                                amount: amount
-                            }
-                        ];
-
+                      // if there is NO shipping method then fail if config says to.
+                      var require_shipping = <?php echo Mage::helper('adyen')->getConfigData('require_shipping', 'adyen_apple_pay'); ?>;
+                      if(require_shipping) {
+                        status = session.STATUS_FAILURE;
+                      }
                     }
 
                     session.completeShippingContactSelection(status, shippingMethods, newTotal, newLineItems);
@@ -347,12 +354,11 @@ if ($this->hasApplePayEnabled()):
                         window.location="/checkout/onepage/success";
                     }
                 }, function(reason) {
+                    var status = session.STATUS_FAILURE;
                     if(reason.message == "ERROR BILLING") {
-                        var status = session.STATUS_INVALID_BILLING_POSTAL_ADDRESS;
+                        status = session.STATUS_INVALID_BILLING_POSTAL_ADDRESS;
                     } else if(reason.message == "ERROR SHIPPING") {
-                        var status = session.STATUS_INVALID_SHIPPING_POSTAL_ADDRESS;
-                    } else {
-                        var status = session.STATUS_FAILURE;
+                        status = session.STATUS_INVALID_SHIPPING_POSTAL_ADDRESS;
                     }
                     session.completePayment(status);
                 });

--- a/shell/adyen.php
+++ b/shell/adyen.php
@@ -26,6 +26,8 @@
  */
 
 // php adyen.php -action loadBillingAgreements
+// php -f shell/adyen.php -- -action updateNotificationQueue
+
 
 require_once 'abstract.php';
 
@@ -189,6 +191,18 @@ class Adyen_Payments_Shell extends Mage_Shell_Abstract
    	public function loadBillingAgreementsActionHelp() {
    		return "";
    	}
+
+    /**
+     * This updates the notifications that are in the adyen event queue. This can be called a system cronjob 
+     */
+    public function updateNotificationQueueAction()
+    {
+        // call ProcessNotifications
+        $_debugData = Mage::getModel('adyen/processNotification')->updateNotProcessedNotifications();
+        if(isset($_debugData['UpdateNotProcessedEvents Step2']) && $_debugData['UpdateNotProcessedEvents Step2'] != 'The queue is empty') {
+          print_r($_debugData);
+        }
+    }
 }
 
 


### PR DESCRIPTION
… cron & updated readme with system cron example

**Description**

Magento's cron system obtains a (locking) write connection on the DB to update jobs in the cron_schedule table fro PENDING to RUNNING and COMPLETED. 

If Magento's cron is configured to run every minute & there is a job to run every minute the database is effectively being locked every minute.

This causes critical writes to the databases relating to order creation to hang or timeout. 

**Tested scenarios**

Client's site was receiving multiple HTTP 499 codes (nginx - client terminated request/timeout) from 3D secure servers while using an alternative payment provider.  Connections were timing out. This was not happening before adding the Adyen extension. Disabling Adyen's cron configuration was the only thing that fixed the problem. Running the updateNotificationQueue() function through a shell process and the system cron works fine & doesn't lock the Magento DB. 

**Fixed issue**:  830

https://github.com/Adyen/adyen-magento/issues/830