### PR TITLE
cron fix - added shell process to run updateNotificationQueue()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ But you can also request or suggest new features or code changes yourself!
 </ul>
 
 <h2>Setup Cron</h2>
-It is needed to enable the Magento cron. Make sure that this is running every minute.
-We are using a cronjob to process the notifications. The cronjob will be executed every minute. It only executes the notifications that have been received at least 5 minutes ago. We have built in this 5 minutes so we are sure Magento has created the order and all save after events are executed.
-A handy tool to get into your cronjobs is AOE scheduler. You can download this tool through <a href="http://www.magentocommerce.com/magento-connect/aoe-scheduler.html" target="_blank">Magento Connect</a> or <a target="_blank" href="https://github.com/AOEpeople/Aoe_Scheduler/releases">GitHub</a>
+Adyen notifications and payment updates are handled periodically every minute by the system cron process. The Adyen shell process can be configured by adding the following to your crontab. Edit accordingly, and replace `/var/www/html` with the web root of your Magento store. 
+
+<code>
+* * * * * /usr/bin/flock -n ~/.adyen_notification_mage.lock /usr/bin/php -f /var/www/html/shell/adyen.php -- -action updateNotificationQueue >> /var/www/html/var/log/adyen_notification_cron.log
+</code>
 
 <h2>Support</h2>
 You can create issues on our Magento Repository or if you have some specific problems for your account you can contact <a href="mailto:magento@adyen.com">magento@adyen.com</a>  as well.

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -655,6 +655,7 @@
             </payment>
         </adyen>
     </default>
+    <!--
     <crontab>
         <jobs>
             <adyen_payment_process_notification_queue>
@@ -667,4 +668,5 @@
             </adyen_payment_process_notification_queue>
         </jobs>
     </crontab>
+    -->
 </config>

--- a/shell/adyen.php
+++ b/shell/adyen.php
@@ -26,6 +26,8 @@
  */
 
 // php adyen.php -action loadBillingAgreements
+// php -f shell/adyen.php -- -action updateNotificationQueue
+
 
 require_once 'abstract.php';
 
@@ -189,6 +191,18 @@ class Adyen_Payments_Shell extends Mage_Shell_Abstract
    	public function loadBillingAgreementsActionHelp() {
    		return "";
    	}
+
+    /**
+     * This updates the notifications that are in the adyen event queue. This can be called a system cronjob 
+     */
+    public function updateNotificationQueueAction()
+    {
+        // call ProcessNotifications
+        $_debugData = Mage::getModel('adyen/processNotification')->updateNotProcessedNotifications();
+        if(isset($_debugData['UpdateNotProcessedEvents Step2']) && $_debugData['UpdateNotProcessedEvents Step2'] != 'The queue is empty') {
+          print_r($_debugData);
+        }
+    }
 }
 
 


### PR DESCRIPTION
… removed Magento cron & updated readme with system cron example

Description

Magento's cron system obtains a (locking) write connection on the DB to update jobs in the cron_schedule table from PENDING to RUNNING and COMPLETED.

If Magento's cron is configured to run every minute & there is a job to run every minute the database is effectively being locked every minute.

This causes critical writes to the databases relating to order creation to hang or timeout.

Tested scenarios

Client's site was receiving multiple HTTP 499 codes (nginx - client terminated request/timeout) from 3D secure servers while using an alternative payment provider. Connections were timing out. This was not happening before adding the Adyen extension. Disabling Adyen's cron configuration was the only thing that fixed the problem. Running the updateNotificationQueue() function through a shell process and the system cron works fine & doesn't lock the Magento DB.

Fixed issue: 830

See also: https://github.com/Adyen/adyen-magento/pull/920