### PR TITLE
Remove bool type cast Zero auth date field

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -237,7 +237,7 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
 
         // check if a zero auth should be done for this order
         $useZeroAuth = (bool)Mage::helper('adyen')->getConfigData('use_zero_auth', null, $order->getStoreId());
-        $zeroAuthDateField = (bool)Mage::helper('adyen')->getConfigData(
+        $zeroAuthDateField = Mage::helper('adyen')->getConfigData(
             'base_zero_auth_on_date', null,
             $order->getStoreId()
         );


### PR DESCRIPTION
**Description**
Line #240 in https://github.com/Adyen/adyen-magento/blob/master/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php is cast to a bool, should be the date field of the base_zero_auth_on_date config.

**Tested scenarios**
<!-- Description of tested scenarios -->

**Fixed issue**:  <!-- #-prefixed issue number -->