### PR TITLE
POS cloud payment method improvements - regenerate order increment ID correctly and gracefully handle quote save exceptions

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/PosController.php
+++ b/app/code/community/Adyen/Payment/controllers/PosController.php
@@ -132,11 +132,20 @@ class Adyen_Payment_PosController extends Mage_Core_Controller_Front_Action
             $quote->getPayment()->setAdditionalInformation('receipt', $formattedReceipt);
         }
 
-        $quote->getPayment()->setAdditionalInformation(
-            'terminalResponse',
-            $response['SaleToPOIResponse']['PaymentResponse']
-        );
-        $quote->save();
+        if (!empty($response['SaleToPOIResponse']['PaymentResponse'])) {
+            $quote->getPayment()->setAdditionalInformation(
+                'terminalResponse',
+                $response['SaleToPOIResponse']['PaymentResponse']
+            );
+        }
+
+        try {
+            $quote->save();
+        } catch (Exception $e) {
+            $result = self::PAYMENT_RETRY;
+            $errorCondition = $e->getMessage();
+            Mage::logException($e);
+        }
 
         $resultArray = array(
             'result' => $result,

--- a/app/code/community/Adyen/Payment/controllers/PosController.php
+++ b/app/code/community/Adyen/Payment/controllers/PosController.php
@@ -56,6 +56,8 @@ class Adyen_Payment_PosController extends Mage_Core_Controller_Front_Action
         $timeStamper = date("Y-m-d") . "T" . date("H:i:s+00:00");
         $customerId = $quote->getCustomerId();
 
+        # Always create new order increment ID, assuring payment transaction is linked to one order only
+        $quote->unsReservedOrderId();
         $reference = $quote->reserveOrderId()->getReservedOrderId();
 
         $request = array(

--- a/app/code/community/Adyen/Payment/controllers/PosController.php
+++ b/app/code/community/Adyen/Payment/controllers/PosController.php
@@ -132,12 +132,15 @@ class Adyen_Payment_PosController extends Mage_Core_Controller_Front_Action
             $quote->getPayment()->setAdditionalInformation('receipt', $formattedReceipt);
         }
 
+        $terminalResponse = "";
         if (!empty($response['SaleToPOIResponse']['PaymentResponse'])) {
-            $quote->getPayment()->setAdditionalInformation(
-                'terminalResponse',
-                $response['SaleToPOIResponse']['PaymentResponse']
-            );
+            $terminalResponse = $response['SaleToPOIResponse']['PaymentResponse'];
         }
+
+        $quote->getPayment()->setAdditionalInformation(
+            'terminalResponse',
+            $terminalResponse
+        );
 
         try {
             $quote->save();


### PR DESCRIPTION
**Description**
Resolves next issues experienced after upgrading to the latest version and activating / testing POS cloud payment method:
* Order increment ID registered to the Adyen transaction was incorrect when payment was canceled and re-attempted. Forcing regeneration of Magento order increment ID on each attempt resolves this.
* Upon quote save failure, the controller would just be halted, breaking the checkout flow. This is now handled gracefully, resulting in the failure being returned to frontend and logged to the Magento exception logs.