### PR TITLE
Fix incorrect order state from pending to pending payment

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -1349,7 +1349,7 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract
 
             // set the state to processing
             // if state is pending - do not change holded orders
-            if($order->getState() == 'pending') {
+            if($order->getState() == Mage_Sales_Model_Order::STATE_PENDING_PAYMENT) {
               $order->setState(Mage_Sales_Model_Order::STATE_PROCESSING);
             }
         }


### PR DESCRIPTION
**Description**
A check was added in the past to not change holded orders. However,
the check was done with a non-existing order state (pending), while
this should have been pending_payment. This is replaced with the
constant defined by Magento itself.

**Tested scenarios**
When creating an order before this fix, while setting the value for the option "Order status: payment authorisation" to "Processing", the order would get the status "Processing" and when setting the state in the first step, the state will also be set to "Processing". Later in the process, when creating an invoice is created, it will be set to "Pending Payment", which should be changed back to "Processing" as soon as the payment is authorised. That didn't happen. This breaks the default Magento Sales Reports, as they check the "state" Processing and not the "status".

**Fixed issue**: N/A