### PR TITLE
Pos cloud backend configuration

### DIFF
--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -1759,7 +1759,8 @@
                         </api_key_test>
                         <api_key_live translate="label">
                             <label>API key for Terminal API LIVE</label>
-                            <frontend_type>text</frontend_type>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
                             <sort_order>45</sort_order>
                             <tooltip>Copy this from the Live Adyen Customer Area => Settings => Users => System => [web
                                 service user]=> Checkout API Key.


### PR DESCRIPTION
**Description**
Makes sure the live api key gets Encrypted when saving it for the POS cloud payment method.

Tested scenarios
Tested on Magento 1.14.4.1 & Adyen 2.13.1
* Placing an order with 'POS Cloud' when the module is set to live mode 
-> validated if the api_live_key is set correctly on the request header
* Saving and updating the api key in the backend

**Fixed issue**:  #990