### PR TITLE
fix for broken polyfill

### DIFF
--- a/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
+++ b/app/design/adminhtml/default/default/template/adyen/form/cc.phtml
@@ -189,7 +189,7 @@ $originKey = $this->getOriginKey();
     }
 
     function polyFill() {
-        if (Array.prototype.filter) {
+        if (!Array.prototype.filter) {
             Array.prototype.filter = function (func, thisArg) {
                 'use strict';
                 if (!((typeof func === 'Function' || typeof func === 'function') && this))

--- a/app/design/frontend/base/default/template/adyen/form/cc.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/cc.phtml
@@ -146,7 +146,7 @@ $originKey = $this->getOriginKey();
             document.getElementById("allValidcard").value = "";
         }
         function polyFill() {
-            if (Array.prototype.filter) {
+            if (!Array.prototype.filter) {
                 Array.prototype.filter = function (func, thisArg) {
                     'use strict';
                     if (!((typeof func === 'Function' || typeof func === 'function') && this))

--- a/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/oneclick.phtml
@@ -71,7 +71,7 @@ $originKey = $this->getOriginKey();
                 <script type="text/javascript">
 
                     function polyFill() {
-                        if (Array.prototype.filter) {
+                        if (!Array.prototype.filter) {
                             Array.prototype.filter = function (func, thisArg) {
                                 'use strict';
                                 if (!((typeof func === 'Function' || typeof func === 'function') && this))


### PR DESCRIPTION
**Plugin version**: 2.14.1
**Description**

https://github.com/Adyen/adyen-magento/commit/bf11beb178b062d32ab033061c55e12b773f60b6#diff-c8da74942a13b71da466352ae7919d06R74

This polyfill doesn't make sense, if Array.prototype.filter exists then we redefine it??

This could potentially break other javascript using Array.prototype.filter if it changes the behavior of the function so it's not compliant with standards.

You refer to this as a Polyfill in the code (function polyFill() {) which is implementing a missing feature, not implementing an already existing feature with something else. Was this a typo? Shouldn't it be:

    if (!Array.prototype.filter) {
        Array.prototype.filter = function (func, thisArg) { // ....

Besides if Array.prototype.filter is NOT defined you don't define it at all so it won't work in older browsers...

If you need a filter function that works differently than the standards then just create a normal function with another name..

I cannot see that `.filter` is ever used in this module though even....