### PR TITLE
Fixed redirect issue for IDEAL & ALI

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/ProcessController.php
+++ b/app/code/community/Adyen/Payment/controllers/ProcessController.php
@@ -127,7 +127,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action
         try {
             $session = $this->_getCheckout();
             $order = $this->_getOrder();
-            $quoteId = $session->getQuoteId();
+            $quoteId = $session->getLastQuoteId();
 
             $session->setAdyenQuoteId($quoteId);
             $session->setAdyenRealOrderId($session->getLastRealOrderId());


### PR DESCRIPTION
**Description**
When selected payment method has an external redirection, such as IDEAL or ALI Pay, order is being created and quote doesn't exist anymore.
For this reason is needed to $session->getLastQuoteId() instead of $session->getQuoteId(), since $session->getQuoteId() doesn't exist or is null.

**Tested scenarios**
When order is already created before going to the external Payment Method page.
