### PR TITLE
Fix undefined pspReference in 3d secure payments

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -602,7 +602,7 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
         }
 
         $responseCode = $response['resultCode'];
-        $pspReference = $response['pspReference'];
+        $pspReference = !empty($response['pspReference']) ? $response['pspReference'] : null;
 
         // save pspreference to match with notification
         $payment->setAdyenPspReference($pspReference);


### PR DESCRIPTION
**Description**
When using 3d secure cards exception is thrown
`Exception: Notice: Undefined index: pspReference in ./app/code/community/Adyen/Payment/Model/Adyen/Abstract.php on line 601 in`

**Tested scenarios**
Tested using 3d secure cards, payment went through correctly