### PR TITLE
Properly redirect from 3ds and apple pay on frontend

### DIFF
--- a/app/design/frontend/base/default/template/adyen/apple_pay.phtml
+++ b/app/design/frontend/base/default/template/adyen/apple_pay.phtml
@@ -346,7 +346,8 @@ if ($this->hasApplePayEnabled()):
 
                     if (success) {
                         // redirect to success page
-                        window.location = "/checkout/onepage/success";
+                        window.location = "<?php echo $this->getUrl('checkout/onepage/success',
+                            array('_secure' => true)); ?>";
                     }
                 }, function(reason) {
                     var status = session.STATUS_FAILURE;

--- a/app/design/frontend/base/default/template/adyen/threeds2.phtml
+++ b/app/design/frontend/base/default/template/adyen/threeds2.phtml
@@ -85,12 +85,15 @@
                     if (response.authentication) {
                         renderThreeDS2Component(response["resultCode"], response["authentication"]["threeds2.challengeToken"]);
                     } else if (response === "Authorised") {
-                        window.location = "/checkout/onepage/success";
+                        window.location = "<?php echo $this->getUrl('checkout/onepage/success',
+                            array('_secure' => true)); ?>";
                     } else if (response === "Refused" || response === "Error") {
-                        window.location = "/checkout/cart";
+                        window.location = "<?php echo $this->getUrl('checkout/cart',
+                            array('_secure' => true)); ?>";
                     }
                 } else {
-                    window.location = "/checkout/cart";
+                    window.location = "<?php echo $this->getUrl('checkout/cart',
+                        array('_secure' => true)); ?>";
                 }
             });
         }


### PR DESCRIPTION
**Description**
Replaces relative redirects for URLs such as 'checkout/onepage/success' with the actual secure URL. This resolves issues when store code is present in the url or when the actual checkout URL is different. 

**Tested scenarios**
Tested the 3ds case on 1.9.4.2 with store code and with a custom front name for onepage checkout.

**Fixed issue**:  #1050