### PR TITLE
Fix for undefined property paymentResult, fixes #1035

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -513,7 +513,7 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
             return false;
         }
 
-        $pspReference = $response->paymentResult->pspReference;
+        $pspReference = null;
 
         switch ($request) {
             case 'refund':


### PR DESCRIPTION
**Description**
Paymentresult is the result of the old api, which is not used anymore

**Fixed issue**:  #1035