### PR TITLE
Review fix

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -981,6 +981,9 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract
                     $status = $fraudManualReviewStatus;
                     $comment = "Adyen Payment is in Manual Review check the Adyen platform";
                     $order->addStatusHistoryComment(Mage::helper('adyen')->__($comment), $status);
+                    if($order->getState() == Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW) {
+                        $order->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+                    }
                     /**
                      * save the order this is needed for older magento version so that status is not reverted to state NEW
                      */

--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -1415,6 +1415,9 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract
             $fraudManualReviewStatus = $this->_getFraudManualReviewStatus($order);
             if ($fraudManualReviewStatus != "") {
                 $status = $fraudManualReviewStatus;
+                if($order->getState() == Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW) {
+                    $order->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+                }
                 $comment = "Adyen Payment is in Manual Review check the Adyen platform";
             }
         }


### PR DESCRIPTION
**Description**
Fixed inconsistent state when an order goes to Manual Review in Case Management. Orders stay in payment_review so they cannot be cancelled when a CANCEL_OR_REFUND notification is received.

**Tested scenarios**
* Place an order. The status state of that order must be payment_review (for example for us happens when using adyen_oneclick)
* Receive a notification with Manual Review
* State is still on pament_review, should be pending_payment

**Fixed issue**:  #1068 