### PR TITLE
Remove default housenumber or name paybylink

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Api.php
+++ b/app/code/community/Adyen/Payment/Model/Api.php
@@ -406,10 +406,6 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
                 "country" => "ZZ"
             );
 
-            if ($paymentMethod === 'pay_by_link') {
-                $requestBillingDefaults['houseNumberOrName'] = 'N/A';
-            }
-
             // Save the defaults for later to compare if anything has changed
             $requestBilling = $requestBillingDefaults;
 
@@ -448,10 +444,6 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
                 "houseNumberOrName" => '',
                 "country" => "ZZ"
             );
-
-            if ($paymentMethod === 'pay_by_link') {
-                $requestDeliveryDefaults['houseNumberOrName'] = 'N/A';
-            }
 
             // Save the defaults for later to compare if anything has changed
             $requestDelivery = $requestDeliveryDefaults;

--- a/app/code/community/Adyen/Payment/Model/Api.php
+++ b/app/code/community/Adyen/Payment/Model/Api.php
@@ -132,7 +132,7 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
             $request = $this->setThreeds2Data($request, $payment);
         }
         $request = $this->setApplicationInfo($request);
-        $request = $this->buildAddressData($request, $billingAddress, $deliveryAddress, $paymentMethod);
+        $request = $this->buildAddressData($request, $billingAddress, $deliveryAddress);
         $request = $this->setRecurringMode($request, $paymentMethod, $payment, $storeId);
         $request = $this->setShopperInteraction($request, $paymentMethod, $payment, $storeId);
         $request = $this->setPaymentSpecificData($request, $paymentMethod, $payment);
@@ -394,7 +394,7 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
      * @param $shippingAddress
      * @return array
      */
-    public function buildAddressData($request, $billingAddress, $shippingAddress, $paymentMethod = null)
+    public function buildAddressData($request, $billingAddress, $shippingAddress)
     {
         if ($billingAddress) {
             // Billing address defaults
@@ -953,7 +953,7 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
         );
 
         $request = $this->setApplicationInfo($request);
-        $request = $this->buildAddressData($request, $billingAddress, $deliveryAddress, $paymentMethod);
+        $request = $this->buildAddressData($request, $billingAddress, $deliveryAddress);
 
         $response = $this->doRequestJson($request, $requestUrl, $apiKey, null);
         return json_decode($response, true);


### PR DESCRIPTION
**Description**
Remove the default value for address housenumberOrName 'N/A' for pay by link. Similar to payments the housenumberOrName default value is not requested

**Tested scenarios**
Do a pay by link cc transaction 

**Fixed issue**:  <!-- #-prefixed issue number -->