### PR TITLE
PW-2162 Move getCurrentLocaleCode from observer to helper, add locale…

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Data.php
+++ b/app/code/community/Adyen/Payment/Helper/Data.php
@@ -734,4 +734,17 @@ class Adyen_Payment_Helper_Data extends Mage_Payment_Helper_Data
         }
         return $request;
     }
+
+    /**
+     * @return string
+     */
+    public function getCurrentLocaleCode($storeId = null)
+    {
+        $localeCode = $this->getConfigData('shopperlocale', 'adyen_abstract', $storeId);
+        if ($localeCode != "") {
+            return $localeCode;
+        }
+
+        return Mage::app()->getLocale()->getLocaleCode();
+    }
 }

--- a/app/code/community/Adyen/Payment/Model/Api.php
+++ b/app/code/community/Adyen/Payment/Model/Api.php
@@ -886,11 +886,9 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
      * Create a payment request
      *
      * @param $payment
-     * @param $amount
-     * @param $paymentMethod
      * @return mixed
      */
-    public function requestToPaymentLinks($order, $paymentMethod)
+    public function requestToPaymentLinks($order)
     {
         // configurations
         $orderCurrencyCode = $order->getOrderCurrencyCode();
@@ -901,6 +899,7 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
         $customerEmail = $order->getCustomerEmail();
         $billingAddress = $order->getBillingAddress();
         $deliveryAddress = $order->getShippingAddress();
+        $storeId = $order->getStoreId();
 
         if ($this->_helper()->getConfigDataDemoMode()) {
             $requestUrl = self::ENDPOINT_CHECKOUT_TEST . "/v41/paymentLinks";
@@ -936,6 +935,7 @@ class Adyen_Payment_Model_Api extends Mage_Core_Model_Abstract
             DATE_ATOM,
             mktime(date("H") + 1, date("i"), date("s"), date("m"), date("j"), date("Y"))
         );
+        $request['shopperLocale'] = Mage::helper('adyen')->getCurrentLocaleCode($storeId);
 
         $request = Mage::helper('adyen')->setApplicationInfo($request, true);
         $request = $this->buildAddressData($request, $billingAddress, $deliveryAddress);

--- a/app/code/community/Adyen/Payment/Model/Observer.php
+++ b/app/code/community/Adyen/Payment/Model/Observer.php
@@ -137,7 +137,7 @@ class Adyen_Payment_Model_Observer
                 mktime(date("H") + 1, date("i"), date("s"), date("m"), date("j"), date("Y"))
             ),
             "countryCode" => $this->_getCurrentCountryCode($adyenHelper, $store),
-            "shopperLocale" => $this->_getCurrentLocaleCode($adyenHelper, $store)
+            "shopperLocale" => $adyenHelper->getCurrentLocaleCode($store->getId())
         );
         $responseData = $this->_getDirectoryLookupResponse($adyFields, $store);
 
@@ -201,21 +201,6 @@ class Adyen_Payment_Model_Observer
     {
         return Mage::getSingleton('checkout/session')->getQuote();
     }
-
-
-    /**
-     * @return string
-     */
-    protected function _getCurrentLocaleCode($adyenHelper, $store)
-    {
-        $localeCode = $adyenHelper->getConfigData('shopperlocale', 'adyen_abstract', $store->getId());
-        if ($localeCode != "") {
-            return $localeCode;
-        }
-
-        return Mage::app()->getLocale()->getLocaleCode();
-    }
-
 
     /**
      * @return string


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
Paybylink order with locale set from Magento and from configuration shows the correct language.
Directory lookup payment methods show the language with the same criteria

**Fixed issue**:  <!-- #-prefixed issue number -->