### PR TITLE
Release 2.18.6

### DIFF
--- a/app/code/community/Adyen/Fee/etc/config.xml
+++ b/app/code/community/Adyen/Fee/etc/config.xml
@@ -33,7 +33,7 @@
 <config>
     <modules>
         <Adyen_Fee>
-            <version>2.18.5</version>
+            <version>2.18.6</version>
         </Adyen_Fee>
     </modules>
     <global>

--- a/app/code/community/Adyen/Payment/Model/ProcessPaybylink.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessPaybylink.php
@@ -45,13 +45,18 @@ class Adyen_Payment_Model_ProcessPaybylink extends Mage_Core_Model_Abstract
 
         $this->debugData['processPaybylink begin'] = 'Begin to process cronjob for cancelling expired Pay By Link orders';
 
+        $hours = Mage::helper('adyen')->getConfigData('expires_after', "adyen_pay_by_link");
+        if ($hours == '') {
+            // Only if no value is set, set it to 1 hour
+            $hours = '1';
+        }
         $orderPaymentCollection = Mage::getModel('sales/order')->getCollection()
             ->join(array('payment' => 'sales/order_payment'),
                 'main_table.entity_id=payment.parent_id',
                 array('payment_method' => 'payment.method'))
             ->addFieldToFilter('created_at', array(
-                    'to' => strtotime('-60 minutes', time()),
-                    'datetime' => true
+                'to' => strtotime('-' . $hours . ' hours', time()),
+                'datetime' => true
                 ))
             ->addFieldToFilter('payment.method', "adyen_pay_by_link")
             ->addAttributeToFilter('state', array('neq' => 'canceled'))

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -490,9 +490,9 @@
                 <model>adyen/adyen_payByLink</model>
                 <group>adyen</group>
                 <visible_type>frontend</visible_type>
-                <title>Pay By link</title>
-                <expires_at>1</expires_at>
-                <sort_order></sort_order>
+                <title>Pay By Link</title>
+                <expires_after>1</expires_after>
+                <sort_order>10</sort_order>
             </adyen_pay_by_link>
             <adyen_apple_pay translate="title" module="adyen">
                 <active>0</active>

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -33,7 +33,7 @@
 <config>
     <modules>
         <Adyen_Payment>
-            <version>2.18.5</version>
+            <version>2.18.6</version>
         </Adyen_Payment>
     </modules>
     <global>

--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -845,6 +845,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </sort_order>
+                        <expires_after translate="label">
+                            <label>Cancel orders after (hours)</label>
+                            <comment>Specify the number of hours after unsuccessful Pay By Link orders will be cancelled.
+                            </comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>27</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </expires_after>
                         <store_payment_method translate="label">
                             <label>Store Payment Details</label>
                             <comment>Tokenize the shopper payment details, as configured on the Customer Area under Account -> Configure -> Checkout</comment>


### PR DESCRIPTION
**Description**

_Pay By Link_ fixes: 
#1098 [PW-2521] Always send `houseNumberOrName` (N/A or parsed from the address field for required countries), added `taxCategory` **`High`** since it is required for Afterpay
#1099 [PW-2511] _Pay By Link_ orders are not cancelled anymore by `AUTHORISATION false `and `OFFER_CLOSED` notifications, added configuration to set the number of hours after the Pay By Link orders are automatically cancelled by a cronjob.
